### PR TITLE
GitHub ActionsでCloudflare Workersへの自動デプロイを追加

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers (Staging)
+
+on:
+  push:
+    branches: [ main ]   # mainブランチにpushされたら実行
+  workflow_dispatch:      # 手動実行も可
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # 1) ソースコードをチェックアウト
+      - uses: actions/checkout@v4
+
+      # 2) Node.js 環境をセットアップ
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 3) 依存関係をインストール
+      - run: npm ci
+
+      # 4) ビルド
+      - run: npm run build
+        env:
+          MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
+          MICROCMS_SERVICE_ID: ${{ secrets.MICROCMS_SERVICE_ID }}
+          MICROCMS_ENDPOINT: ${{ secrets.MICROCMS_ENDPOINT }}
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+
+      # 5) Cloudflare Workers にデプロイ
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: publish --env staging

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,23 @@
+name = "augustaro-com"
+compatibility_date = "2024-08-10"
+
+[env.staging]
+name = "augustaro-com-staging"
+routes = [
+  "staging.augustaro.com/*"
+]
+
+[env.production]
+name = "augustaro-com-production"
+routes = [
+  "augustaro.com/*"
+]
+
+# 静的アセット用の設定
+[[rules]]
+type = "Text"
+globs = ["**/*.html", "**/*.txt", "**/*.css", "**/*.js", "**/*.json"]
+
+[[rules]]
+type = "Data"
+globs = ["**/*.png", "**/*.jpg", "**/*.jpeg", "**/*.gif", "**/*.svg", "**/*.webp", "**/*.woff", "**/*.woff2"]


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローを追加してCloudflare Workersへの自動デプロイを実現
- staging環境用の設定を追加
- wrangler.toml設定ファイルを作成

## 変更内容
- `.github/workflows/deploy-staging.yml`: mainブランチpush時にstaging環境へ自動デプロイ
- `wrangler.toml`: Cloudflare Workers用の環境設定（staging/production分離）

## Test plan
- [ ] GitHubリポジトリのSecretsに必要な環境変数を設定
- [ ] mainブランチへのマージ後、ワークフローが正常に実行されることを確認
- [ ] staging環境でのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)