### PR TITLE
GitHub ActionsでCloudflare Workersへの自動デプロイ設定を追加（v2）

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers (Staging)
+
+on:
+  push:
+    branches: [ master ]   # masterブランチにpushされたら実行
+  workflow_dispatch:       # 手動実行も可
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # 1) ソースコードをチェックアウト
+      - uses: actions/checkout@v4
+
+      # 2) Node.js 環境をセットアップ
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 3) 依存関係をインストール
+      - run: npm ci
+
+      # 4) ビルド
+      - run: npm run build
+        env:
+          MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
+          MICROCMS_SERVICE_ID: ${{ secrets.MICROCMS_SERVICE_ID }}
+          MICROCMS_ENDPOINT: ${{ secrets.MICROCMS_ENDPOINT }}
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+
+      # 5) Cloudflare Workers にデプロイ
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: publish --env staging

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,19 @@ command = "npm run build"
 
 # Environment variables for production
 [env.production]
+name = "augustaro-com-production"
 vars = { NODE_ENV = "production" }
+routes = [
+  "augustaro.com/*"
+]
+
+# Environment variables for staging
+[env.staging]
+name = "augustaro-com-staging"
+vars = { NODE_ENV = "staging" }
+routes = [
+  "staging.augustaro.com/*"
+]
 
 # Environment variables for development
 [env.development]


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローを追加してCloudflare Workersへの自動デプロイを実現
- 既存のwrangler.toml設定をベースにstaging/production環境を分離
- masterブランチへのpush時に自動実行される設定に調整

## 変更内容
- `.github/workflows/deploy-staging.yml`: masterブランチpush時にstaging環境へ自動デプロイ
- `wrangler.toml`: staging/production環境の設定を追加（既存設定を保持）

## Test plan
- [ ] GitHubリポジトリのSecretsに必要な環境変数を設定
- [ ] masterブランチへのマージ後、ワークフローが正常に実行されることを確認
- [ ] staging環境でのデプロイが成功することを確認

## 前回のPRとの差分
- 既存のworker.js設定との競合を解決
- masterブランチベースで作成（コンフリクトなし）
- 既存のwrangler.toml設定を保持しつつ環境設定を拡張

🤖 Generated with [Claude Code](https://claude.ai/code)