### PR TITLE
wrangler-action v3のコマンドをdeployに修正

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
-          command: publish --env production
+          command: deploy --env production


### PR DESCRIPTION
## Summary
wrangler-action v3では`publish`コマンドが`deploy`コマンドに変更されているため修正

## 変更内容
- `.github/workflows/deploy-production.yml`: `command: publish --env production` → `command: deploy --env production`

## 理由
wrangler-action v3でコマンド体系が変更されており、従来の`publish`コマンドは`deploy`コマンドに変更されています。

🤖 Generated with [Claude Code](https://claude.ai/code)