### PR TITLE
環境変数設定問題を修正してMicroCMS連携を有効化

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,15 +20,19 @@ jobs:
       # 3) 依存関係をインストール
       - run: npm ci
 
-      # 4) ビルド
+      # 4) Cloudflare環境変数を設定
+      - run: |
+          echo "MICROCMS_API_KEY=${{ secrets.MICROCMS_API_KEY }}" >> .env.production
+          echo "MICROCMS_SERVICE_ID=${{ secrets.MICROCMS_SERVICE_ID }}" >> .env.production
+          echo "MICROCMS_ENDPOINT=${{ secrets.MICROCMS_ENDPOINT }}" >> .env.production
+          echo "GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}" >> .env.production
+
+      # 5) ビルド
       - run: npm run build
         env:
-          MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
-          MICROCMS_SERVICE_ID: ${{ secrets.MICROCMS_SERVICE_ID }}
-          MICROCMS_ENDPOINT: ${{ secrets.MICROCMS_ENDPOINT }}
-          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+          NODE_ENV: production
 
-      # 5) Cloudflare Workers にデプロイ
+      # 6) Cloudflare Workers にデプロイ
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}


### PR DESCRIPTION
## Summary
GitHub ActionsでCloudflare Workersデプロイ時の環境変数設定問題を修正

## 問題
ワークフローが以下のエラーで失敗していました：
```
error Problems with gatsby-source-microcms plugin options:
"apiKey" is required
"serviceId" is required  
"apis[0].endpoint" is required
```

## 解決方法
- GitHub Actionsでビルド前に`.env.production`ファイルを動的に生成
- GitHub Secretsから環境変数を読み込んで設定
- gatsby-source-microcmsプラグインが必要な環境変数を正しく参照できるよう修正

## 変更内容
- `.github/workflows/deploy-production.yml`: 環境変数設定ステップを追加
- ビルドプロセスでMicroCMSの認証情報を正しく渡すよう修正

🤖 Generated with [Claude Code](https://claude.ai/code)