### PR TITLE
CLOUDFLARE_ACCOUNT_ID環境変数を追加してWrangler認証エラーを修正

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,3 +39,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy --env production
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy --dry-run --env production
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   lint-and-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Wranglerの認証に必要な`CLOUDFLARE_ACCOUNT_ID`環境変数を追加して認証エラーを修正

## 問題
前回の修正で`CLOUDFLARE_API_TOKEN`を正しく設定したにも関わらず、以下の認証エラーが継続：
```
✘ ERROR A request to the Cloudflare API (/memberships) failed.
Unable to authenticate request [code: 10001]
```

## 根本原因
Wranglerの認証には`CLOUDFLARE_API_TOKEN`に加えて`CLOUDFLARE_ACCOUNT_ID`も必要でした。

## 修正内容

### 1. GitHub Secrets統一
- `CF_ACCOUNT_ID` → `CLOUDFLARE_ACCOUNT_ID`に名前変更
- 他のCloudflare関連環境変数との命名規則を統一

### 2. ワークフロー修正
- `deploy-production.yml`: `CLOUDFLARE_ACCOUNT_ID`環境変数を追加
- `test-build.yml`: `CLOUDFLARE_ACCOUNT_ID`環境変数を追加

### 3. ローカル環境
- `.env.production`: `CLOUDFLARE_ACCOUNT_ID`プレースホルダーを追加

## 要対応事項
⚠️ **重要**: `CLOUDFLARE_ACCOUNT_ID`の実際の値を設定する必要があります

Cloudflareダッシュボードの右側サイドバーでアカウントIDを確認し、以下コマンドで設定してください：
```bash
gh secret set CLOUDFLARE_ACCOUNT_ID --body "YOUR_ACTUAL_ACCOUNT_ID"
```

## 期待される結果
- Wranglerの認証が正常に動作
- GitHub Actionsでのデプロイが成功
- test-buildと本番デプロイの整合性確保

🤖 Generated with [Claude Code](https://claude.ai/code)