### PR TITLE
Wrangler認証デバッグ機能追加とコマンド直接実行への変更

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,9 +35,7 @@ jobs:
           NODE_ENV: production
 
       # 6) Cloudflare Workers にデプロイ
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: deploy --env production
+      - run: npx wrangler deploy --env=production
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,7 +34,15 @@ jobs:
         env:
           NODE_ENV: production
 
-      # 6) Cloudflare Workers にデプロイ
+      # 6) Wrangler認証確認
+      - name: Wrangler whoami (sanity check)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: whoami
+
+      # 7) Cloudflare Workers にデプロイ
       - run: npx wrangler deploy --env=production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,7 +32,15 @@ jobs:
         env:
           NODE_ENV: production
 
-      # 6) Wranglerの設定チェック（実際のデプロイは行わない）
+      # 6) Wrangler認証確認
+      - name: Wrangler whoami (sanity check)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: whoami
+
+      # 7) Wranglerの設定チェック（実際のデプロイは行わない）
       - run: npx wrangler deploy --dry-run --env=production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,11 +33,9 @@ jobs:
           NODE_ENV: production
 
       # 6) Wranglerの設定チェック（実際のデプロイは行わない）
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: deploy --dry-run --env production
+      - run: npx wrangler deploy --dry-run --env=production
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   lint-and-format:


### PR DESCRIPTION
## Summary
継続的にCloudflare Workersデプロイが失敗している問題を解決するため、デバッグ機能を追加し、wrangler-actionから直接コマンド実行に変更

## 問題
`cloudflare/wrangler-action@v3`が継続的に失敗し、認証エラーが続いていました。

## 解決策

### 1. デバッグ機能追加
- `wrangler whoami`ステップを追加してCloudflare認証状況を確認
- 失敗の根本原因を特定するためのサニティチェック

### 2. 実行方式の変更
- `cloudflare/wrangler-action@v3` → `npx wrangler`コマンド直接実行
- ローカルでテスト済みの同じコマンドを使用
- 環境変数設定を統一・明確化

### 3. 環境変数統一
- `CLOUDFLARE_API_TOKEN`: 正しい値を設定済み
- `CLOUDFLARE_ACCOUNT_ID`: 実際のアカウントIDを設定済み

## 変更内容
- **deploy-production.yml**: 
  - `wrangler whoami`認証チェック追加
  - 直接`npx wrangler deploy`実行に変更
- **test-build.yml**: 同様のデバッグ機能追加

## 期待される結果
1. `wrangler whoami`で認証状況が明確に確認できる
2. 直接コマンド実行でサードパーティActionの問題を回避
3. ローカル環境と同一の設定・コマンドで信頼性向上

## テスト確認事項
- [ ] `wrangler whoami`ステップが成功するか
- [ ] 認証エラーが解消されるか
- [ ] 実際のデプロイが成功するか

🤖 Generated with [Claude Code](https://claude.ai/code)