### PR TITLE
レトロデザインをメインサイトに変更

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,45 +1,162 @@
-import React, { useEffect } from "react"
-import Layout from "../components/layout"
-import { UserCard } from "../components/UserCard"
-import { ContentsCard } from "../components/ContentsCard"
-import { AppCardList } from "../components/AppCardList"
-import Seo from "../components/seo"
+import React from "react"
 import { graphql } from "gatsby"
+import Seo from "../components/seo"
+import RetroLayout from "../components/retro/RetroLayout"
+import RetroCounter from "../components/retro/RetroCounter"
+import RetroUserCard from "../components/retro/RetroUserCard"
+import RetroContentCard from "../components/retro/RetroContentCard"
+import useWindowSize from "../hooks/useWindowSize"
 
-export const StartPage = ({ location, data }) => {
+const StartPage = ({ data }) => {
   const posts = data.allMicrocmsBlogs.nodes
-  // useEffect(() => {
-  //   alert(posts.map(data => data.title))
-  // }, [])
+  const { width } = useWindowSize()
+  const isPC = width >= 1024 // 1024px以上をPC版とする
+
+  const retroStyles = {
+    marquee: {
+      backgroundColor: '#ff6666',
+      border: '2px solid #000000',
+      padding: '8px',
+      margin: '5px 0',
+      fontSize: '16px',
+      fontWeight: 'bold',
+      animation: 'flashBackground 2s infinite alternate',
+      boxShadow: '0 0 10px #cccccc'
+    },
+    marqueeText: {
+      color: '#ffff00',
+      textShadow: '2px 2px 0px #0000ff, -1px -1px 0px #000000',
+      WebkitTextStroke: '1px #000000',
+      animation: 'flashText 2.5s infinite alternate',
+      fontFamily: '"創英角ポップ体", "Souei Kaku Pop", "HGS創英角ポップ体", "Comic Sans MS", fantasy'
+    },
+    contentGrid: {
+      display: 'table',
+      width: '100%',
+      marginTop: '20px'
+    },
+    leftColumn: {
+      display: 'table-cell',
+      width: '50%',
+      verticalAlign: 'top',
+      paddingRight: '10px'
+    },
+    rightColumn: {
+      display: 'table-cell',
+      width: '50%',
+      verticalAlign: 'top',
+      paddingLeft: '10px'
+    },
+    construction: {
+      backgroundColor: '#fffacd',
+      color: '#000080',
+      padding: '12px',
+      textAlign: 'center',
+      border: '3px inset #c0c0c0',
+      fontWeight: 'normal',
+      fontSize: '11px',
+      fontFamily: '"創英角ポップ体", "Souei Kaku Pop", "HGS創英角ポップ体", "Comic Sans MS", fantasy'
+    },
+    topSection: isPC ? {
+      display: 'table',
+      width: '100%',
+      marginTop: '10px'
+    } : {},
+    counterColumn: isPC ? {
+      display: 'table-cell',
+      width: '50%',
+      verticalAlign: 'top',
+      paddingRight: '10px'
+    } : {},
+    profileColumn: isPC ? {
+      display: 'table-cell',
+      width: '50%',
+      verticalAlign: 'top',
+      paddingLeft: '10px'
+    } : {}
+  }
+
   return (
     <>
-      <Layout location={location}>
-        <Seo
-          title="AugusTaroの館"
-          eyecatch="https://augustaro.github.io/My_Images/MyIcon/MyIcon.jpg"
-        >
-          <div className="flex justify-center  ">
-            <div className="px-5 pt-5  max-w-md ">
-              <UserCard />
+      <style>
+        {`
+          @keyframes flashBackground {
+            0% { background-color: #ff6666; }
+            50% { background-color: #6666ff; }
+            100% { background-color: #ff6666; }
+          }
+          @keyframes flashText {
+            0% { color: #ffff00; text-shadow: 2px 2px 0px #0000ff, -1px -1px 0px #000000; }
+            50% { color: #ff0000; text-shadow: 2px 2px 0px #ffff00, -1px -1px 0px #000000; }
+            100% { color: #ffff00; text-shadow: 2px 2px 0px #0000ff, -1px -1px 0px #000000; }
+          }
+        `}
+      </style>
+      <Seo
+        title="オーガスタロウの館"
+        description="90年代風のホームページです。懐かしいWebデザインでお楽しみください。"
+        eyecatch="https://augustaro.github.io/My_Images/MyIcon/MyIcon.jpg"
+      />
+      <RetroLayout title="オーガスタロウの館">
+        <div style={retroStyles.marquee}>
+          <marquee behavior="scroll" direction="left" scrollamount="3">
+            <span style={retroStyles.marqueeText}>
+              ★★★ Welcome to Augustaro's YAKATA!! ようこそオーガスタロウの館へ！ ★★★
+            </span>
+          </marquee>
+        </div>
 
-              <div className="flex justify-center my-5">
-                <div className="grid grid-cols-2  gap-4">
-                  <ContentsCard
+        {isPC ? (
+          <div style={retroStyles.topSection}>
+            <div style={retroStyles.counterColumn}>
+              <RetroUserCard />
+            </div>
+            <div style={retroStyles.profileColumn}>
+              <RetroCounter />
+              <div style={retroStyles.contentGrid}>
+                <div style={retroStyles.leftColumn}>
+                  <RetroContentCard
                     title="ブログ"
-                    discribe="個人開発に関する技術記事、その他雑記を投稿しています！"
+                    describe="個人開発に関する技術記事、その他雑記を投稿しています！ぜひご覧ください。"
                     link="/blogIndex"
                   />
-                  <AppCardList
+                </div>
+                <div style={retroStyles.rightColumn}>
+                  <RetroContentCard
                     title="アプリ"
-                    discribe="作成したWebアプリを追加予定です！"
-                    apps={posts}
+                    describe="作成したWebアプリを追加予定です！随時更新していきます。"
+                    link="/blogIndex/?category=WebApp"
                   />
                 </div>
               </div>
             </div>
           </div>
-        </Seo>
-      </Layout>
+        ) : (
+          <>
+            <RetroCounter />
+            <RetroUserCard />
+            <hr style={{ border: 'none', borderTop: '2px solid #000000', margin: '15px 0' }} />
+            <div style={retroStyles.contentGrid}>
+              <div style={retroStyles.leftColumn}>
+                <RetroContentCard
+                  title="ブログ"
+                  describe="個人開発に関する技術記事、その他雑記を投稿しています！ぜひご覧ください。"
+                  link="/blogIndex"
+                />
+              </div>
+              <div style={retroStyles.rightColumn}>
+                <RetroContentCard
+                  title="アプリ"
+                  describe="作成したWebアプリを追加予定です！随時更新していきます。"
+                  link="/blogIndex/?category=WebApp"
+                />
+              </div>
+            </div>
+          </>
+        )}
+
+
+      </RetroLayout>
     </>
   )
 }

--- a/src/pages/old.jsx
+++ b/src/pages/old.jsx
@@ -1,162 +1,45 @@
-import React from "react"
-import { graphql } from "gatsby"
+import React, { useEffect } from "react"
+import Layout from "../components/layout"
+import { UserCard } from "../components/UserCard"
+import { ContentsCard } from "../components/ContentsCard"
+import { AppCardList } from "../components/AppCardList"
 import Seo from "../components/seo"
-import RetroLayout from "../components/retro/RetroLayout"
-import RetroCounter from "../components/retro/RetroCounter"
-import RetroUserCard from "../components/retro/RetroUserCard"
-import RetroContentCard from "../components/retro/RetroContentCard"
-import useWindowSize from "../hooks/useWindowSize"
+import { graphql } from "gatsby"
 
-const OldPage = ({ data }) => {
+export const OldPage = ({ location, data }) => {
   const posts = data.allMicrocmsBlogs.nodes
-  const { width } = useWindowSize()
-  const isPC = width >= 1024 // 1024px以上をPC版とする
-
-  const retroStyles = {
-    marquee: {
-      backgroundColor: '#ff6666',
-      border: '2px solid #000000',
-      padding: '8px',
-      margin: '5px 0',
-      fontSize: '16px',
-      fontWeight: 'bold',
-      animation: 'flashBackground 2s infinite alternate',
-      boxShadow: '0 0 10px #cccccc'
-    },
-    marqueeText: {
-      color: '#ffff00',
-      textShadow: '2px 2px 0px #0000ff, -1px -1px 0px #000000',
-      WebkitTextStroke: '1px #000000',
-      animation: 'flashText 2.5s infinite alternate',
-      fontFamily: '"創英角ポップ体", "Souei Kaku Pop", "HGS創英角ポップ体", "Comic Sans MS", fantasy'
-    },
-    contentGrid: {
-      display: 'table',
-      width: '100%',
-      marginTop: '20px'
-    },
-    leftColumn: {
-      display: 'table-cell',
-      width: '50%',
-      verticalAlign: 'top',
-      paddingRight: '10px'
-    },
-    rightColumn: {
-      display: 'table-cell',
-      width: '50%',
-      verticalAlign: 'top',
-      paddingLeft: '10px'
-    },
-    construction: {
-      backgroundColor: '#fffacd',
-      color: '#000080',
-      padding: '12px',
-      textAlign: 'center',
-      border: '3px inset #c0c0c0',
-      fontWeight: 'normal',
-      fontSize: '11px',
-      fontFamily: '"創英角ポップ体", "Souei Kaku Pop", "HGS創英角ポップ体", "Comic Sans MS", fantasy'
-    },
-    topSection: isPC ? {
-      display: 'table',
-      width: '100%',
-      marginTop: '10px'
-    } : {},
-    counterColumn: isPC ? {
-      display: 'table-cell',
-      width: '50%',
-      verticalAlign: 'top',
-      paddingRight: '10px'
-    } : {},
-    profileColumn: isPC ? {
-      display: 'table-cell',
-      width: '50%',
-      verticalAlign: 'top',
-      paddingLeft: '10px'
-    } : {}
-  }
-
+  // useEffect(() => {
+  //   alert(posts.map(data => data.title))
+  // }, [])
   return (
     <>
-      <style>
-        {`
-          @keyframes flashBackground {
-            0% { background-color: #ff6666; }
-            50% { background-color: #6666ff; }
-            100% { background-color: #ff6666; }
-          }
-          @keyframes flashText {
-            0% { color: #ffff00; text-shadow: 2px 2px 0px #0000ff, -1px -1px 0px #000000; }
-            50% { color: #ff0000; text-shadow: 2px 2px 0px #ffff00, -1px -1px 0px #000000; }
-            100% { color: #ffff00; text-shadow: 2px 2px 0px #0000ff, -1px -1px 0px #000000; }
-          }
-        `}
-      </style>
-      <Seo
-        title="オーガスタロウの館 - レトロver"
-        description="90年代風のホームページです。懐かしいWebデザインでお楽しみください。"
-        eyecatch="https://augustaro.github.io/My_Images/MyIcon/MyIcon.jpg"
-      />
-      <RetroLayout title="オーガスタロウの館">
-        <div style={retroStyles.marquee}>
-          <marquee behavior="scroll" direction="left" scrollamount="3">
-            <span style={retroStyles.marqueeText}>
-              ★★★ Welcome to Augustaro's YAKATA!! ようこそオーガスタロウの館へ！ ★★★
-            </span>
-          </marquee>
-        </div>
+      <Layout location={location}>
+        <Seo
+          title="AugusTaroの館 - モダンver"
+          eyecatch="https://augustaro.github.io/My_Images/MyIcon/MyIcon.jpg"
+        >
+          <div className="flex justify-center  ">
+            <div className="px-5 pt-5  max-w-md ">
+              <UserCard />
 
-        {isPC ? (
-          <div style={retroStyles.topSection}>
-            <div style={retroStyles.counterColumn}>
-              <RetroUserCard />
-            </div>
-            <div style={retroStyles.profileColumn}>
-              <RetroCounter />
-              <div style={retroStyles.contentGrid}>
-                <div style={retroStyles.leftColumn}>
-                  <RetroContentCard
+              <div className="flex justify-center my-5">
+                <div className="grid grid-cols-2  gap-4">
+                  <ContentsCard
                     title="ブログ"
-                    describe="個人開発に関する技術記事、その他雑記を投稿しています！ぜひご覧ください。"
+                    discribe="個人開発に関する技術記事、その他雑記を投稿しています！"
                     link="/blogIndex"
                   />
-                </div>
-                <div style={retroStyles.rightColumn}>
-                  <RetroContentCard
+                  <AppCardList
                     title="アプリ"
-                    describe="作成したWebアプリを追加予定です！随時更新していきます。"
-                    link="/blogIndex/?category=WebApp"
+                    discribe="作成したWebアプリを追加予定です！"
+                    apps={posts}
                   />
                 </div>
               </div>
             </div>
           </div>
-        ) : (
-          <>
-            <RetroCounter />
-            <RetroUserCard />
-            <hr style={{ border: 'none', borderTop: '2px solid #000000', margin: '15px 0' }} />
-            <div style={retroStyles.contentGrid}>
-              <div style={retroStyles.leftColumn}>
-                <RetroContentCard
-                  title="ブログ"
-                  describe="個人開発に関する技術記事、その他雑記を投稿しています！ぜひご覧ください。"
-                  link="/blogIndex"
-                />
-              </div>
-              <div style={retroStyles.rightColumn}>
-                <RetroContentCard
-                  title="アプリ"
-                  describe="作成したWebアプリを追加予定です！随時更新していきます。"
-                  link="/blogIndex/?category=WebApp"
-                />
-              </div>
-            </div>
-          </>
-        )}
-
-
-      </RetroLayout>
+        </Seo>
+      </Layout>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- `/old` にあったレトロなデザインのサイトをルートページ (`/`) に移動
- 従来のモダンなデザインを `/old` ページに移動  
- 各コンポーネント名とページタイトルを適切に変更

## 変更内容
- `src/pages/index.jsx`: レトロデザインのコンテンツに置き換え
- `src/pages/old.jsx`: モダンデザインのコンテンツに置き換え
- コンポーネント名の調整 (`StartPage` ↔ `OldPage`)
- ページタイトルの更新

## Test plan
- [ ] ルートページ (`/`) でレトロデザインが表示されることを確認
- [ ] `/old` ページでモダンデザインが表示されることを確認
- [ ] ブログリンク等の内部リンクが正常に動作することを確認
- [ ] ビルドエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)