### PR TITLE
eyecatchがnullの場合のビルドエラーを修正

### DIFF
--- a/src/components/ModalButton.jsx
+++ b/src/components/ModalButton.jsx
@@ -24,7 +24,7 @@ export const ModalButton = props => {
                   <>
                     <AppCard
                       title={app.title}
-                      eyeCatch={app.eyecatch.url}
+                      eyeCatch={app.eyecatch?.url}
                       link={`/articles/${app.blogsId}`}
                     />
                     <AppCard

--- a/src/pages/blogIndex.jsx
+++ b/src/pages/blogIndex.jsx
@@ -42,7 +42,7 @@ const BlogIndex = ({ data, location }) => {
               const key = post.id
               const createdAt = post.createdAt
               const category = post.category
-              const eyecatch = post.eyecatch.url
+              const eyecatch = post.eyecatch?.url
               return (
                 <div className="p-2">
                   <ArticleCard

--- a/src/templates/article.jsx
+++ b/src/templates/article.jsx
@@ -25,7 +25,7 @@ const ArticlePost = ({ data, location }) => {
             ? post.content.slice(0, 150)
             : "コンテンツが存在しません。"
         }
-        eyecatch={post.eyecatch.url}
+        eyecatch={post.eyecatch?.url}
       ></Seo>
       <div className="prose mx-auto pt-5 px-3 lg:max-w-full font-serif ">
         <h1 className="">{post.title}</h1>


### PR DESCRIPTION
## 概要
GitHubワークフローでビルドが失敗していた問題を修正しました。MicroCMSから取得した記事データの`eyecatch`フィールドがnullの場合に、`url`プロパティへのアクセスでTypeErrorが発生していました。

## 変更内容

### 1. オプショナルチェイニングの追加
記事のeyecatchフィールドにアクセスする際に、オプショナルチェイニング(`?.`)を使用してnullセーフなアクセスに変更しました。

- `post.eyecatch.url` → `post.eyecatch?.url`
- `app.eyecatch.url` → `app.eyecatch?.url`

### 2. 修正されたファイル
- `src/templates/article.jsx` - 記事詳細ページのSEOコンポーネント
- `src/pages/blogIndex.jsx` - ブログ一覧ページの記事カード表示
- `src/components/ModalButton.jsx` - アプリモーダル内のアプリカード表示

## 修正された問題点
- GitHubワークフローの`npm run build`ステップで発生していたTypeErrorを解消
- 特定の記事ID（1y3g_-2jzwo）でビルドが失敗していた問題を修正
- eyecatchがnullの記事でもビルドが正常に完了するようになりました

## 動作確認
- [x] ローカルでビルドが成功することを確認 ✓
- [x] eyecatchがnullの記事でもエラーが発生しないことを確認 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)